### PR TITLE
HSC-55:Adds TLS Support for Odoo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     ports:
       - "${PROXY_PUBLIC_PORT}:80"
       - "${PROXY_PUBLIC_PORT_TLS}:443"
+      - "${ODOO_PUBLIC_PORT}:8069"
     volumes:
       - "./proxy/confs:/usr/local/apache2/conf/extra"
       - "${PROXY_TLS_CERTS_PATH:-proxy-tls-certs}:/etc/tls"
@@ -366,8 +367,6 @@ services:
       - "${ODOO_EXTRA_ADDONS:-odoo-extra-addons}:/mnt/extra-addons"
       - "${ODOO_CONFIG_PATH:-odoo-config}:/mnt/odoo_config"
       - "${ODOO_CONFIG_CHECKSUM_PATH:-odoo-checksums}:/mnt/odoo_csv_checksum"
-    ports:
-      - "${ODOO_PUBLIC_PORT:-8069}:8069"
 
   eip-client:
     depends_on:

--- a/proxy/confs/030-odoo-8069.conf
+++ b/proxy/confs/030-odoo-8069.conf
@@ -1,0 +1,12 @@
+<VirtualHost *:8069>
+  #Odoo
+  ProxyPass        /      http://odoo:8069/
+  ProxyPassReverse /      http://odoo:8069/
+  <IfDefine enableTLS>
+    LoadModule ssl_module modules/mod_ssl.so
+    SSLEngine on
+    SSLCertificateFile "/etc/tls/cert.pem"
+    SSLCertificateKeyFile "/etc/tls/privkey.pem"
+    SSLCertificateChainFile "/etc/tls/chain.pem"
+  </IfDefine>
+</VirtualHost>


### PR DESCRIPTION
Adds Odoo VirtualHost of port 8069 and move the odoo public port to the proxy 